### PR TITLE
[Feat] 커뮤니티 날짜 매핑 다시

### DIFF
--- a/IRecipe/app/src/main/java/com/umcproject/irecipe/presentation/ui/community/CommunityPostAdapter.kt
+++ b/IRecipe/app/src/main/java/com/umcproject/irecipe/presentation/ui/community/CommunityPostAdapter.kt
@@ -10,6 +10,11 @@ import com.umcproject.irecipe.R
 import com.umcproject.irecipe.databinding.ItemPostBinding
 import com.umcproject.irecipe.domain.model.Post
 import com.umcproject.irecipe.presentation.util.Util
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 class CommunityPostAdapter(
     private val postList: List<Post>,
@@ -26,6 +31,7 @@ class CommunityPostAdapter(
 
         holder.setPost(post)
         post.postId?.let{ holder.onClickPostEvent(it) }
+        post.createdAt?.let { holder.dateBind(dayDifference(it)) }
     }
 
     override fun getItemCount(): Int = postList.size
@@ -55,5 +61,34 @@ class CommunityPostAdapter(
                 else binding.ivHeart.setImageResource(R.drawable.ic_heart_empty)
             }
         }
+        fun dateBind(text: String) { binding.tvTime.text = text}
+    }
+
+    fun dayDifference(date: String): String {
+
+        val currentTime = Calendar.getInstance().time
+        val createdAtTime = getDateFromString(date)
+
+        val dayDiff = dayDiff(createdAtTime, currentTime)
+
+        val dayDiffText: String = when {
+            dayDiff == 0L -> "오늘"
+            dayDiff in 1L..13L -> "${dayDiff}일 전"
+            dayDiff in 14L..29L -> "${dayDiff/7}주 전" // 13일부터 2주, 4주까지 표시
+            dayDiff >= 30L && dayDiff < 360L -> "${dayDiff / 30}달 전" // 1~11달
+            else -> "${dayDiff / 365}년 전" // n년 전
+
+        }
+        return dayDiffText
+    }
+    private fun getDateFromString(date: String): Date {
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        format.timeZone = TimeZone.getTimeZone("UTC")
+        return format.parse(date)!!
+    }
+
+    private fun dayDiff(start: Date, end: Date): Long {
+        val diff = end.time - start.time
+        return diff / (1000 * 60 * 60 * 24)
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat72-communityPostDate

### 변경 사항
2024-02-17로 나오던 날짜가 n일 전으로 나오게 바꿨습니다
24시간 이하로 차이 -> 오늘
1일 ~ 13일 -> n일 전
14~29일 -> n주 전
n달 전
n년 전

이와 같이 변경하였으나 수정원하시면 고치겠습니다!

### 테스트 결과
ex) 정상동작해야합니다
[date.webm](https://github.com/IRECIPE/IRECIPE-Android/assets/121880741/dc2fda39-d8a3-4ba3-97f4-45b21088da1a)

